### PR TITLE
Raise "close" event when worker processes terminate

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -73,6 +73,7 @@ function WorkerChild (eventDest, filename) {
   
   this.child.addListener("exit", function (code) {
     debug(self.child.pid + ": exit "+code);
+	self.eventDest.emit("close", code);
   });
   
   this.buffer = "";


### PR DESCRIPTION
It'd be incredibly useful to be able to tell when a worker process terminates, to for example spawn a new one, or just log the completion of the process. This patch adds an event that is raised along with the exit code from the process. It does not apply to TCP workers just yet.

Usage:

```
worker.addListener('close', function(code) {
    console.log('Worker child exited with ' + code);
});
```
