### PR TITLE
Raise "close" event when worker processes terminate

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ http://www.whatwg.org/specs/web-workers/current-work/
       worker.terminate();
     });
 
+    // Optional, if you want to be notified when a worker child exits
+    worker.addListener('close', function(code) {
+	  sys.puts('Worker exited with exit code ' + code);
+    });
+
 ## Example Worker File
 
     var worker = require("worker").worker;

--- a/example/example.js
+++ b/example/example.js
@@ -16,3 +16,7 @@ worker.addListener("message", function (msg) {
   sys.puts(msg.hello);
   worker.terminate();
 });
+
+worker.addListener('close', function(code) {
+  sys.puts('Worker exited with exit code ' + code);
+});

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -73,7 +73,7 @@ function WorkerChild (eventDest, filename) {
   
   this.child.addListener("exit", function (code) {
     debug(self.child.pid + ": exit "+code);
-	self.eventDest.emit("close", code);
+    self.eventDest.emit("close", code);
   });
   
   this.buffer = "";

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -73,6 +73,7 @@ function WorkerChild (eventDest, filename) {
   
   this.child.addListener("exit", function (code) {
     debug(self.child.pid + ": exit "+code);
+	self.eventDest.emit("close", code);
   });
   
   this.buffer = "";

--- a/test/fixtures/worker.js
+++ b/test/fixtures/worker.js
@@ -20,6 +20,11 @@ worker.onmessage = function (msg) {
     if(msg.error) {
       throw("ErrorMarker");
     }
+
+    if(msg.exitCode) {
+      process.exit(msg.exitCode);
+      return;
+    }
     
     msg.output = msg.input * 3;
     setTimeout(function () {


### PR DESCRIPTION
_Updated pull request that contains alignment fixes, unit tests and usage instructions. Strangely I wasn't able to append the pull request to the existing one._

It'd be incredibly useful to be able to tell when a worker process terminates, to for example spawn a new one, or just log the completion of the process. This patch adds an event that is raised along with the exit code from the process. It does not apply to TCP workers just yet.

Usage:

```
worker.addListener('close', function(code) {
    console.log('Worker child exited with ' + code);
});
```
