### PR TITLE
Allow path to node executable to be configured

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -37,7 +37,7 @@ var Worker = function (filename, impl, options) {
   });
   
   if(!impl) impl = WorkerChild;
-  this.impl = new impl(this, filename, options);
+  this.impl = new impl(this, filename, options || {});
   this.workerIndex = workerIndex++;
 };
  
@@ -53,11 +53,12 @@ Worker.prototype.terminate = function () {
  
 exports.Worker = Worker;
  
-function WorkerChild (eventDest, filename) {
+function WorkerChild (eventDest, filename, options) {
   var self = this;
   this.eventDest  = eventDest;
   this.filename = filename;
-  this.child = child_process.spawn("node", [this.filename].concat(WORKER_PARAS));
+  var nodePath = options.nodePath || "node";
+  this.child = child_process.spawn(nodePath, [this.filename].concat(WORKER_PARAS));
   this.child.stdout.addListener("data", function (data) {
     debug("From worker " + data);
     self.handleData(data);

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -142,7 +142,7 @@ WorkerChild.prototype = {
   },
   
   terminate: function () {
-    this.child.stdin.end();
+    this.child.kill();
   }
 };
  

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -50,6 +50,10 @@ Worker.prototype.postMessage =  function (payload) {
 Worker.prototype.terminate = function () {
   this.impl.terminate();
 };
+
+Worker.prototype.kill = function () {
+  this.impl.kill();
+};
  
 exports.Worker = Worker;
  
@@ -142,6 +146,10 @@ WorkerChild.prototype = {
   },
   
   terminate: function () {
+    this.child.stdin.end();
+  },
+
+  kill: function () {
     this.child.kill();
   }
 };


### PR DESCRIPTION
Using the default systemwide node executable may not always be desired. This commit allows you to provide an optional path to a node binary to be used.
